### PR TITLE
Fix bug that calls the wrong solve function when using CVXR/ECOS

### DIFF
--- a/R/optrdd.R
+++ b/R/optrdd.R
@@ -441,7 +441,7 @@ optrdd = function(X,
             Amat[(meq+1):nrow(Amat),] %*% xx >= bvec[(meq+1):nrow(Amat)]
         )
         cvx.problem = CVXR::Problem(CVXR::Minimize(objective), contraints)
-        cvx.output = solve(cvx.problem, solver = optimizer, verbose = verbose)
+        cvx.output = CVXR::solve(cvx.problem, solver = optimizer, verbose = verbose)
         
         if (cvx.output$status != "optimal") {
             warning(paste0("CVXR returned with status: ",


### PR DESCRIPTION
This commit fixes bug that calls the wrong solve function when using CVXR/ECOS as the optimizer.